### PR TITLE
support common parameters for all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ api.usersGet({ userIds: ['1'] })
 
 ```js
 interface VKApiOptions {
+    lang?: string|number,
+    testMode?: number,
     logger?: BaseLogger,
     token?: string,
     timeout?: number,
@@ -40,6 +42,18 @@ interface VKApiOptions {
     useQueue?: boolean
 }
 ```
+
+* lang?
+
+Determines the language for the data to be displayed on. For example country and city names.
+If you use a non-cyrillic language, cyrillic symbols will be transtiterated automatically  
+`en – English, ru – Russian, ua – Ukrainian, be – Belorussian, es – Spanish, fi – finnish, de – German, it – Italian.`  
+Numeric format from `account.getInfo` is supported as well.
+
+
+* test_mode?
+
+1 – allows to send requests from a native app without switching it on for all users.
 
 * logger?
 

--- a/src/VKApi.ts
+++ b/src/VKApi.ts
@@ -11,6 +11,8 @@ const API_BASE_URL = 'https://api.vk.com/method/'
 const API_VERSION = '5.62'
 
 export interface VKApiOptions {
+    lang?: string|number,
+    testMode?: number,
     logger?: BaseLogger,
     token?: string,
     timeout?: number,
@@ -19,6 +21,8 @@ export interface VKApiOptions {
 }
 
 export class VKApi {
+    private _lang: string|number|undefined
+    private _testMode: number|undefined
     private _logger: BaseLogger|undefined
     private _queue: CallbackQueue|undefined
     private _timeout: number
@@ -28,6 +32,8 @@ export class VKApi {
         this._logger = options.logger
         this._token = options.token
         this._timeout = options.timeout || TIMEOUT
+        this._lang = options.lang
+        this._testMode = options.testMode
 
         if (options.useQueue)
             this._queue = new CallbackQueue(options.requestsPerSecond || REQUESTS_PER_SECOND)
@@ -35,6 +41,12 @@ export class VKApi {
 
     public async call(method: string, params: Object, responseType?: Function): Promise<any> {
         params = this.filterParams(params)
+
+        if (params['lang'] == undefined && this._lang != undefined)
+            params['lang'] = this._lang
+
+        if (params['testMode'] == undefined && this._testMode != undefined)
+            params['testMode'] = this._testMode
 
         params['v'] = API_VERSION
         params['access_token'] = params['access_token'] || this._token


### PR DESCRIPTION
`https` parameter is redundant because VK is `https://vk.com` only