### PR TITLE
Fix ошибки в работе photosGetWallUploadServer

### DIFF
--- a/src/Responses.ts
+++ b/src/Responses.ts
@@ -7871,7 +7871,7 @@ export class PhotosGetWallUploadServerResponse {
      */
     static deserialize(raw: Object): PhotosGetWallUploadServerResponse {
         return new PhotosGetWallUploadServerResponse (
-            raw['response'] ? Models.PhotosPhotoUpload.deserialize(raw['response']) : undefined
+            raw ? Models.PhotosPhotoUpload.deserialize(raw) : undefined
         )
     }
 }


### PR DESCRIPTION
Ответ от серверов ВК в этот метод приходит в виде уже готового к десериализации объекта доступного напрямую. Без обращения через .response