### PR TITLE
Fix 414 Request-URI Too Long

### DIFF
--- a/src/api/net.ts
+++ b/src/api/net.ts
@@ -2,7 +2,7 @@ const req = require('tiny_request')
 
 export async function postRequest(url: string, query: { [key: string]: any }, timeout = 5000): Promise<{ body: any, response: any, err: Error }> {
     return new Promise<any>((resolve, reject) => {
-        req.post({ url, query, json: true, timeout }, (body: any, response: any, err: Error) => {
+        req.post({ url, form: query, json: true, timeout }, (body: any, response: any, err: Error) => {
             resolve({ body, response, err })
         })
     })


### PR DESCRIPTION
Hi, I'm getting 414 error while calling [execute](https://vk.com/dev/execute) method with large data.

According to documentation

> Параметры могут передаваться как методом GET, так и POST. Если вы будете передавать большие данные (больше 2 килобайт), следует использовать POST.

Sending data with POST form fixes it